### PR TITLE
Result limit

### DIFF
--- a/mndot_bid_api/db/interface.py
+++ b/mndot_bid_api/db/interface.py
@@ -17,10 +17,24 @@ class DBModelInterface:
         self.model = model
         self.configured_sessionmaker = configured_sessionmaker
 
-    def read_all(self) -> list[RecordDict]:
-        """Returns all existing database records from the associated table."""
+    def read_all(self, limit: int = 0) -> list[RecordDict]:
+        """Returns all existing database records from the associated table.
+
+        Limit values:
+         - Negative: Returns no records
+         - Zero: Returns all records (default)
+         - Positive: Returns a number of records equal to the limit
+        """
+        if limit < 0:
+            return []
+
         with self.configured_sessionmaker() as db:
-            records = db.query(self.model).all()
+            records = None
+            if limit > 0:
+                records = db.query(self.model).limit(limit).all()
+            else:
+                records = db.query(self.model).all()
+
             if not records:
                 return []
 

--- a/mndot_bid_api/db/interface.py
+++ b/mndot_bid_api/db/interface.py
@@ -58,10 +58,23 @@ class DBModelInterface:
 
             return models.to_dict(record)
 
-    def read_all_by_kwargs(self, **kwargs) -> list[RecordDict]:
-        """Returns the all existing database records that match the given keyward arguments."""
+    def read_all_by_kwargs(self, limit: int = 0, **kwargs) -> list[RecordDict]:
+        """Returns the all existing database records that match the given keyward arguments.
+
+        Limit values:
+         - Negative: Returns no records
+         - Zero: Returns all records (default)
+         - Positive: Returns a number of records equal to the limit
+        """
+        if limit < 0:
+            return []
+
         with self.configured_sessionmaker() as db:
-            records = db.query(self.model).filter_by(**kwargs).all()
+            records = None
+            if limit > 0:
+                records = db.query(self.model).filter_by(**kwargs).limit(limit).all()
+            else:
+                records = db.query(self.model).filter_by(**kwargs).all()
             if not records:
                 raise RecordNotFoundError()
 

--- a/mndot_bid_api/operations/bidders.py
+++ b/mndot_bid_api/operations/bidders.py
@@ -62,12 +62,14 @@ def delete_bidder(bidder_id: int, bidder_interface: CRUDInterface) -> None:
         exceptions.raise_http_404(model_name="Bidder", id=bidder_id, exc=exc)
 
 
-def query_bidder(bidder_interface: CRUDInterface, **kwargs) -> schema.BidderCollection:
+def query_bidder(
+    bidder_interface: CRUDInterface, limit: int, **kwargs
+) -> schema.BidderCollection:
     if not kwargs:
         exceptions.raise_http_400_empty_query()
 
     try:
-        records = bidder_interface.read_all_by_kwargs(**kwargs)
+        records = bidder_interface.read_all_by_kwargs(limit=limit, **kwargs)
 
     except exceptions.RecordNotFoundError as exc:
         exceptions.raise_http_404_query(model_name="Bidder", exc=exc)

--- a/mndot_bid_api/operations/bidders.py
+++ b/mndot_bid_api/operations/bidders.py
@@ -2,8 +2,10 @@ from mndot_bid_api import exceptions, schema
 from mndot_bid_api.operations.crud_interface import CRUDInterface
 
 
-def read_all_bidders(bidder_interface: CRUDInterface) -> schema.BidderCollection:
-    records = bidder_interface.read_all()
+def read_all_bidders(
+    limit: int, bidder_interface: CRUDInterface
+) -> schema.BidderCollection:
+    records = bidder_interface.read_all(limit)
     results = [schema.BidderResult(**record) for record in records]
 
     return schema.BidderCollection(data=results)

--- a/mndot_bid_api/operations/bids.py
+++ b/mndot_bid_api/operations/bids.py
@@ -84,13 +84,15 @@ def delete_bid(bid_id: int, bid_interface: CRUDInterface) -> None:
         exceptions.raise_http_404(model_name="Bid", id=bid_id, exc=exc)
 
 
-def query_bid(bid_interface: CRUDInterface, **kwargs) -> schema.BidCollection:
+def query_bid(
+    bid_interface: CRUDInterface, limit: int, **kwargs
+) -> schema.BidCollection:
 
     if not kwargs:
         exceptions.raise_http_400_empty_query()
 
     try:
-        records = bid_interface.read_all_by_kwargs(**kwargs)
+        records = bid_interface.read_all_by_kwargs(limit=limit, **kwargs)
 
     except exceptions.RecordNotFoundError as exc:
         exceptions.raise_http_404_query(model_name="Bid", exc=exc)

--- a/mndot_bid_api/operations/bids.py
+++ b/mndot_bid_api/operations/bids.py
@@ -2,8 +2,8 @@ from mndot_bid_api import exceptions, schema
 from mndot_bid_api.operations.crud_interface import CRUDInterface
 
 
-def read_all_bids(bid_interface: CRUDInterface) -> schema.BidCollection:
-    records = bid_interface.read_all()
+def read_all_bids(limit: int, bid_interface: CRUDInterface) -> schema.BidCollection:
+    records = bid_interface.read_all(limit)
     results = [schema.BidResult(**record) for record in records]
 
     return schema.BidCollection(data=results)

--- a/mndot_bid_api/operations/contracts.py
+++ b/mndot_bid_api/operations/contracts.py
@@ -66,13 +66,13 @@ def delete_contract(contract_id: int, contract_interface: CRUDInterface) -> None
 
 
 def query_contract(
-    contract_interface: CRUDInterface, **kwargs
+    contract_interface: CRUDInterface, limit: int, **kwargs
 ) -> schema.ContractCollection:
     if not kwargs:
         exceptions.raise_http_400_empty_query()
 
     try:
-        records = contract_interface.read_all_by_kwargs(**kwargs)
+        records = contract_interface.read_all_by_kwargs(limit=limit, **kwargs)
 
     except exceptions.RecordNotFoundError as exc:
         exceptions.raise_http_404_query(model_name="Contract", exc=exc)

--- a/mndot_bid_api/operations/contracts.py
+++ b/mndot_bid_api/operations/contracts.py
@@ -2,8 +2,10 @@ from mndot_bid_api import exceptions, schema
 from mndot_bid_api.operations.crud_interface import CRUDInterface
 
 
-def read_all_contracts(contract_interface: CRUDInterface) -> schema.ContractCollection:
-    records = contract_interface.read_all()
+def read_all_contracts(
+    limit: int, contract_interface: CRUDInterface
+) -> schema.ContractCollection:
+    records = contract_interface.read_all(limit)
 
     results = [schema.ContractResult(**record) for record in records]
 

--- a/mndot_bid_api/operations/crud_interface.py
+++ b/mndot_bid_api/operations/crud_interface.py
@@ -13,7 +13,7 @@ class CRUDInterface(Protocol):
     def read_one_by_kwargs(self, **kwargs) -> RecordDict:
         ...
 
-    def read_all_by_kwargs(self, **kwargs) -> list[RecordDict]:
+    def read_all_by_kwargs(self, limit: int = 0, **kwargs) -> list[RecordDict]:
         ...
 
     def create(self, data: RecordDict) -> RecordDict:

--- a/mndot_bid_api/operations/crud_interface.py
+++ b/mndot_bid_api/operations/crud_interface.py
@@ -4,7 +4,7 @@ RecordDict = dict[str, Any]
 
 
 class CRUDInterface(Protocol):
-    def read_all(self) -> list[RecordDict]:
+    def read_all(self, limit: int = 0) -> list[RecordDict]:
         ...
 
     def read_by_id(self, id: int) -> RecordDict:

--- a/mndot_bid_api/operations/invalid_bids.py
+++ b/mndot_bid_api/operations/invalid_bids.py
@@ -70,13 +70,13 @@ def delete_invalid_bid(
 
 
 def query_invalid_bid(
-    invalid_bid_interface: CRUDInterface, **kwargs
+    invalid_bid_interface: CRUDInterface, limit: int, **kwargs
 ) -> schema.InvalidBidCollection:
     if not kwargs:
         exceptions.raise_http_400_empty_query()
 
     try:
-        records = invalid_bid_interface.read_all_by_kwargs(**kwargs)
+        records = invalid_bid_interface.read_all_by_kwargs(limit=limit, **kwargs)
 
     except exceptions.RecordNotFoundError as exc:
         exceptions.raise_http_404_query(model_name="Invalid Bid", exc=exc)

--- a/mndot_bid_api/operations/invalid_bids.py
+++ b/mndot_bid_api/operations/invalid_bids.py
@@ -3,9 +3,10 @@ from mndot_bid_api.operations.crud_interface import CRUDInterface
 
 
 def read_all_invalid_bids(
+    limit: int,
     invalid_bid_interface: CRUDInterface,
 ) -> schema.InvalidBidCollection:
-    records = invalid_bid_interface.read_all()
+    records = invalid_bid_interface.read_all(limit)
     results = [schema.InvalidBidResult(**record) for record in records]
 
     return schema.InvalidBidCollection(data=results)

--- a/mndot_bid_api/operations/items.py
+++ b/mndot_bid_api/operations/items.py
@@ -2,8 +2,8 @@ from mndot_bid_api import exceptions, schema
 from mndot_bid_api.operations.crud_interface import CRUDInterface
 
 
-def read_all_items(item_interface: CRUDInterface) -> schema.ItemCollection:
-    records = item_interface.read_all()
+def read_all_items(limit: int, item_interface: CRUDInterface) -> schema.ItemCollection:
+    records = item_interface.read_all(limit)
     results = [schema.ItemResult(**record) for record in records]
 
     return schema.ItemCollection(data=results)

--- a/mndot_bid_api/operations/items.py
+++ b/mndot_bid_api/operations/items.py
@@ -58,12 +58,14 @@ def delete_item(item_id: int, item_interface: CRUDInterface) -> None:
         exceptions.raise_http_404(model_name="Item", id=item_id, exc=exc)
 
 
-def query_item(item_interface: CRUDInterface, **kwargs) -> schema.ItemCollection:
+def query_item(
+    item_interface: CRUDInterface, limit: int, **kwargs
+) -> schema.ItemCollection:
     if not kwargs:
         exceptions.raise_http_400_empty_query()
 
     try:
-        records = item_interface.read_all_by_kwargs(**kwargs)
+        records = item_interface.read_all_by_kwargs(limit=limit, **kwargs)
 
     except exceptions.RecordNotFoundError as exc:
         exceptions.raise_http_404_query(model_name="Item", exc=exc)

--- a/mndot_bid_api/routers/bidders.py
+++ b/mndot_bid_api/routers/bidders.py
@@ -11,10 +11,11 @@ bidder_router = fastapi.APIRouter(prefix="/bidder", tags=["bidder"])
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_read_all_bidders(
+    limit: int = 100,
     bidder_interface=fastapi.Depends(db.get_bidder_interface),
 ) -> schema.BidderCollection:
 
-    return operations.bidders.read_all_bidders(bidder_interface)
+    return operations.bidders.read_all_bidders(limit, bidder_interface)
 
 
 @bidder_router.get(

--- a/mndot_bid_api/routers/bidders.py
+++ b/mndot_bid_api/routers/bidders.py
@@ -79,7 +79,9 @@ def api_delete_bidder(
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_query_bidder(
-    name: str | None = None, bidder_interface=fastapi.Depends(db.get_bidder_interface)
+    name: str | None = None,
+    bidder_interface=fastapi.Depends(db.get_bidder_interface),
+    limit: int = 100,
 ) -> schema.BidderCollection:
     kwargs = locals()
 
@@ -87,7 +89,7 @@ def api_query_bidder(
     filtered_kwargs = {
         key: value
         for key, value in kwargs.items()
-        if value and key != "bidder_interface"
+        if value and key not in ["bidder_interface", "limit"]
     }
 
-    return operations.bidders.query_bidder(bidder_interface, **filtered_kwargs)
+    return operations.bidders.query_bidder(bidder_interface, limit, **filtered_kwargs)

--- a/mndot_bid_api/routers/bids.py
+++ b/mndot_bid_api/routers/bids.py
@@ -93,12 +93,15 @@ def api_query_bid(
     bidder_id: int | None = None,
     bid_type: enums.BidType | None = None,
     bid_interface=fastapi.Depends(db.get_bid_interface),
+    limit: int = 100,
 ) -> schema.BidCollection:
     kwargs = locals()
 
     # Filter for non-None keyword arguments to pass to the query function
     filtered_kwargs = {
-        key: value for key, value in kwargs.items() if value and key != "bid_interface"
+        key: value
+        for key, value in kwargs.items()
+        if value and key not in ["bid_interface", "limit"]
     }
 
-    return operations.bids.query_bid(bid_interface, **filtered_kwargs)
+    return operations.bids.query_bid(bid_interface, limit, **filtered_kwargs)

--- a/mndot_bid_api/routers/bids.py
+++ b/mndot_bid_api/routers/bids.py
@@ -11,10 +11,11 @@ bid_router = fastapi.APIRouter(prefix="/bid", tags=["bid"])
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_read_all_bids(
+    limit: int = 100,
     bid_interface=fastapi.Depends(db.get_bid_interface),
 ) -> schema.BidCollection:
 
-    return operations.bids.read_all_bids(bid_interface)
+    return operations.bids.read_all_bids(limit, bid_interface)
 
 
 @bid_router.get(

--- a/mndot_bid_api/routers/contracts.py
+++ b/mndot_bid_api/routers/contracts.py
@@ -81,13 +81,14 @@ def api_delete_contract(
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_query_contract(
-    contract_interface=fastapi.Depends(db.get_contract_interface),
     letting_date: date | None = None,
     sp_number: str | None = None,
     district: str | None = None,
     county: str | None = None,
     description: str | None = None,
     winning_bidder_id: int | None = None,
+    contract_interface=fastapi.Depends(db.get_contract_interface),
+    limit: int = 100,
 ) -> schema.ContractCollection:
     kwargs = locals()
 
@@ -95,7 +96,9 @@ def api_query_contract(
     filtered_kwargs = {
         key: value
         for key, value in kwargs.items()
-        if value and key != "contract_interface"
+        if value and key not in ["contract_interface", "limit"]
     }
 
-    return operations.contracts.query_contract(contract_interface, **filtered_kwargs)
+    return operations.contracts.query_contract(
+        contract_interface, limit, **filtered_kwargs
+    )

--- a/mndot_bid_api/routers/contracts.py
+++ b/mndot_bid_api/routers/contracts.py
@@ -13,10 +13,11 @@ contract_router = fastapi.APIRouter(prefix="/contract", tags=["contract"])
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_read_all_contracts(
+    limit: int = 100,
     contract_interface=fastapi.Depends(db.get_contract_interface),
 ) -> schema.ContractCollection:
 
-    return operations.contracts.read_all_contracts(contract_interface)
+    return operations.contracts.read_all_contracts(limit, contract_interface)
 
 
 @contract_router.get(

--- a/mndot_bid_api/routers/invalid_bids.py
+++ b/mndot_bid_api/routers/invalid_bids.py
@@ -85,7 +85,6 @@ def api_delete_invalid_bid(
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_query_invalid_bid(
-    invalid_bid_interface=fastapi.Depends(db.get_invalid_bid_interface),
     contract_id: int | None = None,
     bidder_id: int | None = None,
     item_spec_code: str | None = None,
@@ -96,6 +95,8 @@ def api_query_invalid_bid(
     quantity: float | None = None,
     unit_price: int | None = None,
     bid_type: enums.BidType | None = None,
+    invalid_bid_interface=fastapi.Depends(db.get_invalid_bid_interface),
+    limit: int = 100,
 ) -> schema.InvalidBidCollection:
     kwargs = locals()
 
@@ -103,9 +104,9 @@ def api_query_invalid_bid(
     filtered_kwargs = {
         key: value
         for key, value in kwargs.items()
-        if value and key != "invalid_bid_interface"
+        if value and key not in ["invalid_bid_interface", "limit"]
     }
 
     return operations.invalid_bids.query_invalid_bid(
-        invalid_bid_interface, **filtered_kwargs
+        invalid_bid_interface, limit, **filtered_kwargs
     )

--- a/mndot_bid_api/routers/invalid_bids.py
+++ b/mndot_bid_api/routers/invalid_bids.py
@@ -11,10 +11,11 @@ invalid_bid_router = fastapi.APIRouter(prefix="/invalid_bid", tags=["invalid_bid
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_read_all_invalid_bids(
+    limit: int = 100,
     invalid_bid_interface=fastapi.Depends(db.get_invalid_bid_interface),
 ) -> schema.InvalidBidCollection:
 
-    return operations.invalid_bids.read_all_invalid_bids(invalid_bid_interface)
+    return operations.invalid_bids.read_all_invalid_bids(limit, invalid_bid_interface)
 
 
 @invalid_bid_router.get(

--- a/mndot_bid_api/routers/items.py
+++ b/mndot_bid_api/routers/items.py
@@ -78,7 +78,6 @@ def api_delete_item(
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_query_item(
-    item_interface=fastapi.Depends(db.get_item_interface),
     spec_code: str | None = None,
     unit_code: str | None = None,
     item_code: str | None = None,
@@ -90,12 +89,16 @@ def api_query_item(
     in_spec_2018: bool | None = None,
     in_spec_2020: bool | None = None,
     in_spec_2022: bool | None = None,
+    item_interface=fastapi.Depends(db.get_item_interface),
+    limit: int = 100,
 ) -> schema.ItemCollection:
     kwargs = locals()
 
     # Filter for non-None keyword arguments to pass to the query function
     filtered_kwargs = {
-        key: value for key, value in kwargs.items() if value and key != "item_interface"
+        key: value
+        for key, value in kwargs.items()
+        if value and key not in ["item_interface", "limit"]
     }
 
-    return operations.items.query_item(item_interface, **filtered_kwargs)
+    return operations.items.query_item(item_interface, limit, **filtered_kwargs)

--- a/mndot_bid_api/routers/items.py
+++ b/mndot_bid_api/routers/items.py
@@ -11,10 +11,11 @@ item_router = fastapi.APIRouter(prefix="/item", tags=["item"])
     status_code=fastapi.status.HTTP_200_OK,
 )
 def api_read_all_items(
+    limit: int = 100,
     item_interface=fastapi.Depends(db.get_item_interface),
 ) -> schema.ItemCollection:
 
-    return operations.items.read_all_items(item_interface)
+    return operations.items.read_all_items(limit, item_interface)
 
 
 @item_router.get(

--- a/tests/db/test_interface_read_all.py
+++ b/tests/db/test_interface_read_all.py
@@ -11,11 +11,20 @@ def generic_read_all_test(
     expected_result: list[RecordDict],
 ) -> None:
     interface = DBModelInterface(model, configured_sessionmaker)
+
+    # Test limit default; expect all records
     record_dicts = interface.read_all()
     assert len(record_dicts) == len(expected_result)
-
     for record_dict in record_dicts:
         assert record_dict in expected_result
+
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all(limit=1)
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all(limit=-1)
+    assert len(record_dicts) == 0
 
 
 def test_read_all_bidders(configured_sessionmaker: sessionmaker):

--- a/tests/db/test_interface_read_all_by_kwargs.py
+++ b/tests/db/test_interface_read_all_by_kwargs.py
@@ -33,6 +33,14 @@ def test_read_all_by_kwargs_bidders(configured_sessionmaker: sessionmaker):
     with pytest.raises(InvalidRequestError):
         interface.read_all_by_kwargs(invalid_key=100)
 
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all_by_kwargs(limit=1, name=None)
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all_by_kwargs(limit=-1, name=None)
+    assert len(record_dicts) == 0
+
 
 def test_read_all_by_kwargs_contracts(configured_sessionmaker: sessionmaker):
     model = models.Contract
@@ -56,6 +64,14 @@ def test_read_all_by_kwargs_contracts(configured_sessionmaker: sessionmaker):
     # Invalid kwarg
     with pytest.raises(InvalidRequestError):
         interface.read_all_by_kwargs(invalid_key=100)
+
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all_by_kwargs(limit=1, sp_number="5625-20")
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all_by_kwargs(limit=-1, sp_number="5625-20")
+    assert len(record_dicts) == 0
 
 
 def test_read_all_by_kwargs_items(configured_sessionmaker: sessionmaker):
@@ -83,6 +99,14 @@ def test_read_all_by_kwargs_items(configured_sessionmaker: sessionmaker):
     with pytest.raises(InvalidRequestError):
         interface.read_all_by_kwargs(invalid_key=100)
 
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all_by_kwargs(limit=1, in_spec_2020=True)
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all_by_kwargs(limit=-1, in_spec_2020=True)
+    assert len(record_dicts) == 0
+
 
 def test_read_all_by_kwargs_bids(configured_sessionmaker: sessionmaker):
     model = models.Bid
@@ -107,6 +131,14 @@ def test_read_all_by_kwargs_bids(configured_sessionmaker: sessionmaker):
     # Invalid kwarg
     with pytest.raises(InvalidRequestError):
         interface.read_all_by_kwargs(invalid_key=100)
+
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all_by_kwargs(limit=1, bid_type="losing")
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all_by_kwargs(limit=-1, bid_type="losing")
+    assert len(record_dicts) == 0
 
 
 def test_read_all_by_kwargs_invalid_bids(configured_sessionmaker: sessionmaker):
@@ -133,3 +165,11 @@ def test_read_all_by_kwargs_invalid_bids(configured_sessionmaker: sessionmaker):
     # Invalid kwarg
     with pytest.raises(InvalidRequestError):
         interface.read_all_by_kwargs(invalid_key=100)
+
+    # Test positive limit; expect one record
+    record_dicts = interface.read_all_by_kwargs(limit=1, bid_type="losing")
+    assert len(record_dicts) == 1
+
+    # Test negative limit; expect no records
+    record_dicts = interface.read_all_by_kwargs(limit=-1, bid_type="losing")
+    assert len(record_dicts) == 0

--- a/tests/operations/test_operations_query.py
+++ b/tests/operations/test_operations_query.py
@@ -36,16 +36,27 @@ def generic_query_test(
     ]
     expected_result = result_schema(data=expected_result_data)
 
-    result = operation_function(interface, **query_kwargs)
+    # Test with high limit; expect all records
+    result = operation_function(interface, limit=100, **query_kwargs)
     assert result.type == expected_result.type
     assert result.data == expected_result.data
 
+    # Test with positive limit; expect one record
+    result = operation_function(interface, limit=1, **query_kwargs)
+    assert len(result.data) == 1
+
+    # Test with negative limit; expect no records
+    result = operation_function(interface, limit=-1, **query_kwargs)
+    assert len(result.data) == 0
+
+    # Test no kwargs raises
     with pytest.raises(fastapi.HTTPException) as exc:
-        operation_function(interface)
+        operation_function(interface, limit=100)
     assert exc.value.status_code == 400
 
+    # Test invalid kwarg value raises
     with pytest.raises(fastapi.HTTPException) as exc:
-        operation_function(interface, id=-7)
+        operation_function(interface, limit=100, id=-7)
     assert exc.value.status_code == 404
 
 

--- a/tests/operations/test_operations_read_all.py
+++ b/tests/operations/test_operations_read_all.py
@@ -38,11 +38,23 @@ def generic_read_all_test(
     ]
     expected_result = result_schema(data=expected_result_data)
 
-    result = operation_function(interface)
+    # Test valid limit
+    limit = 100
+    result = operation_function(limit, interface)
     assert result.type == expected_result.type
     assert len(result.data) == len(expected_result.data)
     for item in result.data:
         assert item in expected_result.data
+
+    # Test limit of zero returns all records
+    limit = 0
+    result = operation_function(limit, interface)
+    assert len(result.data) == len(expected_result.data)
+
+    # Test negative limit returns no records
+    limit = -500
+    result = operation_function(limit, interface)
+    assert len(result.data) == 0
 
 
 def test_read_all_bidders(configured_sessionmaker: sessionmaker):


### PR DESCRIPTION
Add limit (integer) parameter to read_all and query routes to prevent the API from sending huge response payloads by default.